### PR TITLE
Support v14 Miniupnpc

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1109,10 +1109,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Small fix

```
src/net.cpp:1115:68: error: invalid conversion from ‘int*’ to ‘unsigned char’ [-fpermissive]
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
                                                                    ^~~~~~
src/net.cpp:1115:74: error: too few arguments to function ‘UPNPDev* upnpDiscover(int, const char*, const char*, int, int, unsigned char, int*)’
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);

```